### PR TITLE
fix: shows more appropriate error when metamask isnt connected

### DIFF
--- a/packages/frontend/components/Error.tsx
+++ b/packages/frontend/components/Error.tsx
@@ -5,6 +5,7 @@ import {
   AlertIcon,
   AlertTitle,
 } from '@chakra-ui/react'
+import { useEthers } from '@usedapp/core'
 
 /**
  * Prop Types
@@ -18,9 +19,10 @@ interface ErrorProps {
  */
 export function Error({ message }: ErrorProps): JSX.Element {
   const [errorMsg, setErrorMsg] = useState(String)
+  const { account } = useEthers()
 
   useEffect(() => {
-    if (message === 'unknown account #0') {
+    if (account === null) {
       setErrorMsg('No metamask account connected')
     } else {
       setErrorMsg(message)

--- a/packages/frontend/components/Error.tsx
+++ b/packages/frontend/components/Error.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Alert,
   AlertDescription,
@@ -17,11 +17,20 @@ interface ErrorProps {
  * Component
  */
 export function Error({ message }: ErrorProps): JSX.Element {
+  const [errorMsg, setErrorMsg] = useState(String)
+
+  useEffect(() => {
+    if (message === 'unknown account #0') {
+      setErrorMsg('No metamask account connected')
+    } else {
+      setErrorMsg(message)
+    }
+  }, [])
   return (
     <Alert status="error" mb="8">
       <AlertIcon />
       <AlertTitle mr={2}>Error:</AlertTitle>
-      <AlertDescription>{message}</AlertDescription>
+      <AlertDescription>{errorMsg}</AlertDescription>
     </Alert>
   )
 }

--- a/packages/frontend/components/Error.tsx
+++ b/packages/frontend/components/Error.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import {
   Alert,
   AlertDescription,
   AlertIcon,
   AlertTitle,
 } from '@chakra-ui/react'
-import { useEthers } from '@usedapp/core'
 
 /**
  * Prop Types
@@ -18,21 +17,11 @@ interface ErrorProps {
  * Component
  */
 export function Error({ message }: ErrorProps): JSX.Element {
-  const [errorMsg, setErrorMsg] = useState(String)
-  const { account } = useEthers()
-
-  useEffect(() => {
-    if (account === null) {
-      setErrorMsg('No metamask account connected')
-    } else {
-      setErrorMsg(message)
-    }
-  }, [])
   return (
     <Alert status="error" mb="8">
       <AlertIcon />
       <AlertTitle mr={2}>Error:</AlertTitle>
-      <AlertDescription>{errorMsg}</AlertDescription>
+      <AlertDescription>{message}</AlertDescription>
     </Alert>
   )
 }

--- a/packages/frontend/components/api/Consumer.tsx
+++ b/packages/frontend/components/api/Consumer.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Text, Button } from '@chakra-ui/react'
-import { useContractFunction, TransactionState } from '@usedapp/core'
+import { useContractFunction, TransactionState, useEthers } from '@usedapp/core'
 import { BigNumber, utils } from 'ethers'
 import { useContract } from '../../hooks/useContract'
 import { ContractId } from '../../conf/config'
 import { Error } from '../../components/Error'
+import { checkForNoAcc } from '../../lib/utils'
 // @ts-ignore
 import { APIConsumer } from '../../../types/typechain'
 
@@ -27,17 +28,17 @@ const getLoadingText = (status: TransactionState) =>
  * Component
  */
 export function Consumer(): JSX.Element {
+  const { account } = useEthers()
+
   const [requestId, setRequestId] = useState('')
   const [volumeData, setVolumeData] = useState<BigNumber | undefined>()
 
   const apiConsumer = useContract<APIConsumer>(ContractId.ApiConsumer)
-
   const { send, state, events } = useContractFunction(
     apiConsumer,
     'requestVolumeData',
     { transactionName: 'External API Request' }
   )
-
   const requestVolumeData = async () => {
     await send()
     setVolumeData(null)
@@ -81,6 +82,7 @@ export function Consumer(): JSX.Element {
         isLoading={isLoading}
         loadingText={getLoadingText(state.status)}
         colorScheme="teal"
+        disabled={checkForNoAcc(account)}
       >
         Request External API
       </Button>

--- a/packages/frontend/components/vrf/RandomNFT/index.tsx
+++ b/packages/frontend/components/vrf/RandomNFT/index.tsx
@@ -71,7 +71,6 @@ export function RandomNFT(): JSX.Element {
       }
     }
   }, [createEvents])
-
   useEffect(() => {
     if (randomSvg && tokenId) {
       randomSvg.on('CreatedUnfinishedRandomSVG', (id: BigNumber) => {

--- a/packages/frontend/components/vrf/RandomNFT/index.tsx
+++ b/packages/frontend/components/vrf/RandomNFT/index.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { Text, Image, Button, Stack, Tooltip } from '@chakra-ui/react'
-import { useContractFunction } from '@usedapp/core'
+import { useContractFunction, useEthers } from '@usedapp/core'
 import { BigNumber } from '@ethersproject/bignumber'
-import { getRequestStatus } from '../../../lib/utils'
+import { getRequestStatus, checkForNoAcc } from '../../../lib/utils'
 import { useContract } from '../../../hooks/useContract'
 import { ContractId } from '../../../conf/config'
 import { ExternalLink } from './ExternalLink'
@@ -35,6 +35,7 @@ export function RandomNFT(): JSX.Element {
   const [metadata, setMetadata] = useState<Metadata | undefined>()
 
   const randomSvg = useContract<RandomSVG>(ContractId.RandomSvg)
+  const { account } = useEthers()
 
   const {
     send: create,
@@ -122,6 +123,7 @@ export function RandomNFT(): JSX.Element {
             isLoading={isCreating}
             loadingText={getRequestStatus(createState.status)}
             colorScheme="teal"
+            disabled={checkForNoAcc(account)}
           >
             {metadata ? 'Request New NFT' : 'Request NFT'}
           </Button>
@@ -140,6 +142,7 @@ export function RandomNFT(): JSX.Element {
             isLoading={isFinishing}
             loadingText="Finishing Minting"
             colorScheme="teal"
+            disabled={checkForNoAcc(account)}
           >
             Finish Minting
           </Button>

--- a/packages/frontend/components/vrf/RandomNumber.tsx
+++ b/packages/frontend/components/vrf/RandomNumber.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Text, Button, Code, Stack } from '@chakra-ui/react'
-import { useContractFunction } from '@usedapp/core'
-import { getRequestStatus } from '../../lib/utils'
+import { useContractFunction, useEthers } from '@usedapp/core'
+import { getRequestStatus, checkForNoAcc } from '../../lib/utils'
 import { useContract } from '../../hooks/useContract'
 import { ContractId } from '../../conf/config'
 import { Error } from '../Error'
@@ -11,6 +11,7 @@ import { RandomNumberConsumer } from '../../../types/typechain'
 export function RandomNumber(): JSX.Element {
   const [requestId, setRequestId] = useState('')
   const [randomNumber, setRandomNumber] = useState('')
+  const { account } = useEthers()
 
   const randomNumberConsumer = useContract<RandomNumberConsumer>(
     ContractId.RandomNumberConsumer
@@ -65,6 +66,7 @@ export function RandomNumber(): JSX.Element {
         isLoading={isLoading}
         loadingText={getRequestStatus(state.status)}
         colorScheme="teal"
+        disabled={checkForNoAcc(account)}
       >
         Request Randomness
       </Button>

--- a/packages/frontend/lib/utils.ts
+++ b/packages/frontend/lib/utils.ts
@@ -43,3 +43,11 @@ export const formatUsd = (value: BigNumber): string =>
 export const getRequestStatus = (status: TransactionState): string =>
   (status === 'Mining' && 'Mining Request') ||
   (status === 'Success' && 'Fulfilling Request')
+
+export const checkForNoAcc = (account) => {
+  if (account == null) {
+    return true
+  } else {
+    return false
+  }
+}


### PR DESCRIPTION
It used to show ambiguous error when there was no metamask account connected to the app. I added a if to check for that and useRef hook fo that. 