### PR TITLE
refactor: rename contracts

### DIFF
--- a/packages/frontend/components/api/RequestBuilder.tsx
+++ b/packages/frontend/components/api/RequestBuilder.tsx
@@ -14,7 +14,7 @@ import { useContractFunction, TransactionState, useEthers } from '@usedapp/core'
 import { Error } from '../../components/Error'
 import { useContract } from '../../hooks/useContract'
 // @ts-ignore
-import { APIRequestBuilder } from 'types/typechain'
+import { APIConsumer } from 'types/typechain'
 
 const DEFAULT_MULTIPLIER = '1000000000000000000'
 const DEFAULT_URL =
@@ -34,10 +34,10 @@ export function RequestBuilder(): JSX.Element {
   const [requestId, setRequestId] = useState('')
   const [data, setData] = useState('')
 
-  const apiRequestBuilder = useContract<APIRequestBuilder>('APIRequestBuilder')
+  const apiConsumer = useContract<APIConsumer>('APIConsumer')
 
   const { send, state, events } = useContractFunction(
-    apiRequestBuilder,
+    apiConsumer,
     'requestData',
     { transactionName: 'External API Request' }
   )
@@ -49,13 +49,13 @@ export function RequestBuilder(): JSX.Element {
   }
 
   const readData = useCallback(async () => {
-    const res = await apiRequestBuilder.data()
+    const res = await apiConsumer.data()
     const data = formatFixed(
       res,
       multiplier.split('').filter((e) => e === '0').length
     )
     setData(data)
-  }, [apiRequestBuilder, multiplier])
+  }, [apiConsumer, multiplier])
 
   useEffect(() => {
     if (events) {
@@ -67,15 +67,15 @@ export function RequestBuilder(): JSX.Element {
   }, [events])
 
   useEffect(() => {
-    if (apiRequestBuilder && requestId) {
-      apiRequestBuilder.on('ChainlinkFulfilled', (id: string) => {
+    if (apiConsumer && requestId) {
+      apiConsumer.on('ChainlinkFulfilled', (id: string) => {
         if (requestId === id) {
           readData()
-          apiRequestBuilder.removeAllListeners()
+          apiConsumer.removeAllListeners()
         }
       })
     }
-  }, [apiRequestBuilder, requestId, readData])
+  }, [apiConsumer, requestId, readData])
 
   const isLoading =
     state.status === 'Mining' || (state.status === 'Success' && !data)

--- a/packages/frontend/components/feeds/SelectFeed.tsx
+++ b/packages/frontend/components/feeds/SelectFeed.tsx
@@ -12,10 +12,11 @@ export function SelectFeed(): JSX.Element {
 
   const { chainId } = useEthers()
 
-  const result = useContractCall<BigNumber>('PriceConsumer', 'getPrice', [
-    base,
-    Denominations.USD,
-  ])
+  const result = useContractCall<BigNumber>(
+    'FeedRegistryConsumer',
+    'getPrice',
+    [base, Denominations.USD]
+  )
 
   return (
     <>

--- a/packages/frontend/contracts/hardhat_contracts.json
+++ b/packages/frontend/contracts/hardhat_contracts.json
@@ -4,8 +4,8 @@
       "name": "rinkeby",
       "chainId": "4",
       "contracts": {
-        "APIRequestBuilder": {
-          "address": "0x76dE7D899Ea3217269BC02DcDB54eAAFA9ec53E1",
+        "APIConsumer": {
+          "address": "0x43a87559277fd5F6F1AdC6e6331998899634e9Aa",
           "abi": [
             {
               "inputs": [
@@ -1139,8 +1139,8 @@
       "name": "kovan",
       "chainId": "42",
       "contracts": {
-        "APIRequestBuilder": {
-          "address": "0x8194198c18B82cB0006D639349899Ea9144D9E72",
+        "APIConsumer": {
+          "address": "0x14005AB90bc520E20Ffd7815Cae64372abb6b04d",
           "abi": [
             {
               "inputs": [
@@ -1366,8 +1366,8 @@
             }
           ]
         },
-        "PriceConsumer": {
-          "address": "0x03dD466218284DbF1e9De8Dd692C1b425095CB65",
+        "FeedRegistryConsumer": {
+          "address": "0xB9ebb63D4820c45a2Db09d71cefA24daBd047b50",
           "abi": [
             {
               "inputs": [
@@ -3650,7 +3650,7 @@
             }
           ]
         },
-        "PriceConsumer": {
+        "FeedRegistryConsumer": {
           "address": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
           "abi": [
             {
@@ -4603,7 +4603,7 @@
             }
           ]
         },
-        "APIRequestBuilder": {
+        "APIConsumer": {
           "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
           "abi": [
             {

--- a/packages/hardhat/contracts/APIConsumer.sol
+++ b/packages/hardhat/contracts/APIConsumer.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.6.6;
 import "@chainlink/contracts/src/v0.6/ChainlinkClient.sol";
 import "@chainlink/contracts/src/v0.6/vendor/Ownable.sol";
 
-contract APIRequestBuilder is ChainlinkClient, Ownable {
+contract APIConsumer is ChainlinkClient, Ownable {
   uint256 public data;
   string public text;
 

--- a/packages/hardhat/contracts/FeedRegistryConsumer.sol
+++ b/packages/hardhat/contracts/FeedRegistryConsumer.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.3;
 import "@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol";
 import "@chainlink/contracts/src/v0.8/Denominations.sol";
 
-contract PriceConsumer {
+contract FeedRegistryConsumer {
   FeedRegistryInterface internal registry;
 
   /**

--- a/packages/hardhat/deploy/02_Deploy_FeedRegistryConsumer.ts
+++ b/packages/hardhat/deploy/02_Deploy_FeedRegistryConsumer.ts
@@ -21,7 +21,7 @@ const func: DeployFunction = async function ({
 
   if (!feedRegistryAddress) return
 
-  await deploy('PriceConsumer', {
+  await deploy('FeedRegistryConsumer', {
     from: deployer,
     args: [feedRegistryAddress],
     log: true,

--- a/packages/hardhat/deploy/06_Deploy_APIConsumer.ts
+++ b/packages/hardhat/deploy/06_Deploy_APIConsumer.ts
@@ -24,7 +24,7 @@ const func: DeployFunction = async function ({
   }
   const { jobId, fee } = networkConfig[chainId]
 
-  await deploy('APIRequestBuilder', {
+  await deploy('APIConsumer', {
     from: deployer,
     args: [oracleAddress, jobId, fee, linkTokenAddress],
     log: true,

--- a/packages/hardhat/deploy/07_Setup_Contracts.ts
+++ b/packages/hardhat/deploy/07_Setup_Contracts.ts
@@ -45,17 +45,15 @@ const func: DeployFunction = async function ({
     })
   }
 
-  // Try Auto-fund APIRequestBuilder contract with LINK
-  const APIRequestBuilder = await deployments.get('APIRequestBuilder')
-  const apiRequestBuilder = await ethers.getContractAt(
-    'APIRequestBuilder',
-    APIRequestBuilder.address
+  // Try Auto-fund APIConsumer contract with LINK
+  const APIConsumer = await deployments.get('APIConsumer')
+  const apiConsumer = await ethers.getContractAt(
+    'APIConsumer',
+    APIConsumer.address
   )
-  if (
-    await autoFundCheck(apiRequestBuilder.address, chainId, linkTokenAddress)
-  ) {
+  if (await autoFundCheck(apiConsumer.address, chainId, linkTokenAddress)) {
     await run('fund-link', {
-      contract: apiRequestBuilder.address,
+      contract: apiConsumer.address,
       linkaddress: linkTokenAddress,
     })
   }

--- a/packages/hardhat/test/integration/APIConsumer.test.ts
+++ b/packages/hardhat/test/integration/APIConsumer.test.ts
@@ -2,23 +2,23 @@ import { ethers, deployments, network } from 'hardhat'
 import { expect } from 'chai'
 import skip from 'mocha-skip-if'
 import { developmentChains } from '../../helper-hardhat-config'
-import { APIRequestBuilder } from 'types/typechain'
+import { APIConsumer } from 'types/typechain'
 
 skip
   .if(developmentChains.includes(network.name))
-  .describe('APIRequestBuilder Integration Tests', () => {
-    let apiRequestBuilder: APIRequestBuilder
+  .describe('APIConsumer Integration Tests', () => {
+    let apiConsumer: APIConsumer
 
     beforeEach(async () => {
-      const APIRequestBuilder = await deployments.get('APIRequestBuilder')
-      apiRequestBuilder = (await ethers.getContractAt(
-        'APIRequestBuilder',
-        APIRequestBuilder.address
-      )) as APIRequestBuilder
+      const APIConsumer = await deployments.get('APIConsumer')
+      apiConsumer = (await ethers.getContractAt(
+        'APIConsumer',
+        APIConsumer.address
+      )) as APIConsumer
     })
 
     it('should successfully make an external API request and get a result', async () => {
-      const transaction = await apiRequestBuilder.requestData(
+      const transaction = await apiConsumer.requestData(
         'https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD',
         'RAW.ETH.USD.VOLUME24HOUR',
         '1000000000000000000'
@@ -29,7 +29,7 @@ skip
       await new Promise((resolve) => setTimeout(resolve, 30000))
 
       //Now check the result
-      const result = await apiRequestBuilder.data()
+      const result = await apiConsumer.data()
       expect(result).to.be.gt(0)
     })
   })

--- a/packages/hardhat/test/integration/FeedRegistryConsumer.test.ts
+++ b/packages/hardhat/test/integration/FeedRegistryConsumer.test.ts
@@ -2,26 +2,26 @@ import { ethers, deployments, network } from 'hardhat'
 import { expect } from 'chai'
 import skip from 'mocha-skip-if'
 import { developmentChains } from '../../helper-hardhat-config'
-import { PriceConsumer } from 'types/typechain'
+import { FeedRegistryConsumer } from 'types/typechain'
 
 skip
   .if(developmentChains.includes(network.name))
-  .describe('PriceConsumer Integration Tests', () => {
-    let priceConsumer: PriceConsumer
+  .describe('FeedRegistryConsumer Integration Tests', () => {
+    let feedRegistryConsumer: FeedRegistryConsumer
 
     beforeEach(async () => {
-      const PriceConsumer = await deployments.get('PriceConsumer')
-      priceConsumer = (await ethers.getContractAt(
-        'PriceConsumer',
-        PriceConsumer.address
-      )) as PriceConsumer
+      const FeedRegistryConsumer = await deployments.get('FeedRegistryConsumer')
+      feedRegistryConsumer = (await ethers.getContractAt(
+        'FeedRegistryConsumer',
+        FeedRegistryConsumer.address
+      )) as FeedRegistryConsumer
     })
 
     it('should successfully make request and get a result', async () => {
       const ethAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
       const usdAddress = '0x0000000000000000000000000000000000000348'
 
-      let result = await priceConsumer.getPrice(ethAddress, usdAddress)
+      let result = await feedRegistryConsumer.getPrice(ethAddress, usdAddress)
       expect(result).to.be.gt(0)
     })
   })

--- a/packages/hardhat/test/unit/APIConsumer.test.ts
+++ b/packages/hardhat/test/unit/APIConsumer.test.ts
@@ -4,12 +4,12 @@ import { expect } from 'chai'
 import skip from 'mocha-skip-if'
 import { developmentChains } from '../../helper-hardhat-config'
 import { autoFundCheck } from '../../utils'
-import { APIRequestBuilder, LinkToken } from 'types/typechain'
+import { APIConsumer, LinkToken } from 'types/typechain'
 
 skip
   .if(!developmentChains.includes(network.name))
-  .describe('APIRequestBuilder Unit Tests', () => {
-    let apiRequestBuilder: APIRequestBuilder, linkToken: LinkToken
+  .describe('APIConsumer Unit Tests', () => {
+    let apiConsumer: APIConsumer, linkToken: LinkToken
 
     beforeEach(async () => {
       const chainId = await getChainId()
@@ -22,28 +22,22 @@ skip
 
       const linkTokenAddress = linkToken.address
 
-      const APIRequestBuilder = await deployments.get('APIRequestBuilder')
-      apiRequestBuilder = (await ethers.getContractAt(
-        'APIRequestBuilder',
-        APIRequestBuilder.address
-      )) as unknown as APIRequestBuilder
+      const APIConsumer = await deployments.get('APIConsumer')
+      apiConsumer = (await ethers.getContractAt(
+        'APIConsumer',
+        APIConsumer.address
+      )) as APIConsumer
 
-      if (
-        await autoFundCheck(
-          apiRequestBuilder.address,
-          chainId,
-          linkTokenAddress
-        )
-      ) {
+      if (await autoFundCheck(apiConsumer.address, chainId, linkTokenAddress)) {
         await run('fund-link', {
-          contract: apiRequestBuilder.address,
+          contract: apiConsumer.address,
           linkaddress: linkTokenAddress,
         })
       }
     })
 
     it('should successfully make an API request', async () => {
-      const transaction = await apiRequestBuilder.requestData(
+      const transaction = await apiConsumer.requestData(
         'https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD',
         'RAW.ETH.USD.VOLUME24HOUR',
         '1000000000000000000'

--- a/packages/hardhat/test/unit/FeedRegistryConsumer.test.ts
+++ b/packages/hardhat/test/unit/FeedRegistryConsumer.test.ts
@@ -3,20 +3,21 @@ import { BigNumber } from 'ethers'
 import { expect } from 'chai'
 import skip from 'mocha-skip-if'
 import { developmentChains } from '../../helper-hardhat-config'
-import { PriceConsumer, MockFeedRegistry } from 'types/typechain'
+import { FeedRegistryConsumer, MockFeedRegistry } from 'types/typechain'
 
 skip
   .if(!developmentChains.includes(network.name))
-  .describe('PriceConsumer Unit Tests', () => {
-    let priceConsumer: PriceConsumer, mockFeedRegistry: MockFeedRegistry
+  .describe('FeedRegistryConsumer Unit Tests', () => {
+    let feedRegistryConsumer: FeedRegistryConsumer
+    let mockFeedRegistry: MockFeedRegistry
 
     beforeEach(async () => {
       await deployments.fixture(['mocks', 'feed'])
-      const PriceConsumer = await deployments.get('PriceConsumer')
-      priceConsumer = (await ethers.getContractAt(
-        'PriceConsumer',
-        PriceConsumer.address
-      )) as PriceConsumer
+      const FeedRegistryConsumer = await deployments.get('FeedRegistryConsumer')
+      feedRegistryConsumer = (await ethers.getContractAt(
+        'FeedRegistryConsumer',
+        FeedRegistryConsumer.address
+      )) as FeedRegistryConsumer
 
       const MockFeedRegistry = await deployments.get('MockFeedRegistry')
       mockFeedRegistry = (await ethers.getContractAt(
@@ -31,7 +32,10 @@ skip
       const mockUSDAddress = '0x0000000000000000000000000000000000000348'
 
       await mockFeedRegistry.updateAnswer(mockEthPrice)
-      let result = await priceConsumer.getPrice(mockEthAddress, mockUSDAddress)
+      let result = await feedRegistryConsumer.getPrice(
+        mockEthAddress,
+        mockUSDAddress
+      )
       expect(result).to.be.equal(mockEthPrice)
     })
   })


### PR DESCRIPTION
Rename for clarity:

`APIRequestBuilder` -> `APIConsumer`
`PriceConsumer` -> `FeedRegistryConsumer`